### PR TITLE
feat: Introduced releasing JSON file as output from the Renamer-CLI

### DIFF
--- a/renamer.ts
+++ b/renamer.ts
@@ -18,6 +18,12 @@ const args: CLIArguments = yargs(hideBin(process.argv))
         type: 'boolean',
         default: false,
     })
+    .option('output', {
+        alias: 'o',
+        describe: 'Provide output file name',
+        type: 'string',
+        default: 'renamed.json',
+    })
     .help()
     .parseSync();
 

--- a/src/__tests__/e2e/renamer.spec.ts
+++ b/src/__tests__/e2e/renamer.spec.ts
@@ -17,6 +17,10 @@ describe('Renamer E2E Tests', () => {
     if (fs.existsSync(testDir)) {
       fs.readdirSync(testDir).forEach(file => fs.unlinkSync(path.join(testDir, file)));
       fs.rmdirSync(testDir);
+      const filePath = path.resolve(__dirname, '../../../renamed.json');
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+      }
     }
   });
 

--- a/src/__tests__/unit/utils.spec.ts
+++ b/src/__tests__/unit/utils.spec.ts
@@ -25,7 +25,7 @@ jest.mock('fs', () => ({
 }));
 
 describe('processFile', () => {
-  const mockArgs = { path: '/path/to/file.txt', debug: false }; 
+  const mockArgs = { path: '/path/to/file.txt', debug: false  , output: 'renamed.json' };
   const mockFilePath = '/path/to/file.txt';
   beforeEach(() => {
     jest.clearAllMocks();
@@ -37,7 +37,7 @@ describe('processFile', () => {
 
     expect(fs.promises.access).toHaveBeenCalledWith(mockFilePath);
     expect(logger.error).toHaveBeenCalledWith(`File does not exist at path: ${mockFilePath}`);
-    expect(result).toBe('skipped');
+    expect(result).toStrictEqual({"newFilePath": null, "status": "skipped"});
   });
   it('should skip if file is empty', async () => {
     (fs.promises.access as jest.Mock).mockResolvedValue(undefined);
@@ -46,7 +46,7 @@ describe('processFile', () => {
     const result = await processFile(mockFilePath, mockArgs);
     
     expect(logger.warn).toHaveBeenCalledWith(`File ${basename(mockFilePath)} is empty, skipping rename.`);
-    expect(result).toBe('skipped');
+    expect(result).toStrictEqual({"newFilePath": null, "status": "skipped"});
   });
   it('should skip renaming if file already has the correct name', async () => {
     const mockContent = 'Some file content';
@@ -59,7 +59,7 @@ describe('processFile', () => {
     const result = await processFile(mockFilePath, mockArgs);
 
     expect(logger.info).toHaveBeenCalledWith(`File ${basename(mockFilePath)} already has the correct name, skipping rename.`);
-    expect(result).toBe('skipped');
+    expect(result).toStrictEqual({"newFilePath": null, "status": "skipped"});
   });
 });
 

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,0 +1,1 @@
+export const renamedInfo: Record<string, { suggested_name: string }> = {};

--- a/src/renameFiles.ts
+++ b/src/renameFiles.ts
@@ -2,17 +2,24 @@ import { promises as fsPromises } from 'fs';
 import { resolve, basename } from 'path';
 import logger from '../logger';
 import { directoryPath, filePath } from './types/renameFiles';
-import { processFile } from './utils';
+import { processFile, writeRenamedInfoToFile } from './utils';
 import { handleError } from './error/errorHandler';
 import { CLIArguments } from './types';
+import { renamedInfo } from './constant';
 const { readdir } = fsPromises;
-
 
 export const renameSingleFile = async (filePath: filePath, args: CLIArguments) => {
     const result = await processFile(filePath, args);
-    if (result === 'error') {
+    if (result.status === 'error') {
         logger.error(`Failed to rename file ${basename(filePath)}`);
     }
+    if (result.status === 'renamed' && result.newFilePath) {
+        renamedInfo[basename(filePath)] = { suggested_name: basename(result.newFilePath) };
+    }
+    if (Object.keys(renamedInfo).length > 0) {
+        await writeRenamedInfoToFile(renamedInfo, args);
+    }
+
 };
 
 export const renameFilesInDirectory = async (directoryPath: directoryPath, args: CLIArguments): Promise<void> => {
@@ -26,13 +33,20 @@ export const renameFilesInDirectory = async (directoryPath: directoryPath, args:
         const processResults = await Promise.allSettled(
             files.map(async (file) => {
                 const filePath = resolve(directoryPath, file);
-                return await processFile(filePath, args);
+                const result = await processFile(filePath, args);
+                if (result.status === 'renamed' && result.newFilePath) {
+                    renamedInfo[basename(filePath)] = { suggested_name: basename(result.newFilePath) };
+                }
+                return result;
             })
         );
 
-        const renamedCount = processResults.filter((result) => result.status === 'fulfilled' && result.value === 'renamed').length;
-        const skippedCount = processResults.filter((result) => result.status === 'rejected' || result.value !== 'renamed').length;
+        const renamedCount = processResults.filter((result) => result.status === 'fulfilled' && result.value.status === 'renamed').length;
 
+        const skippedCount = processResults.filter((result) => result.status === 'fulfilled' && result.value.status === 'skipped').length;
+        if (renamedCount > 0) {
+            await writeRenamedInfoToFile(renamedInfo, args);
+        }
         logger.info(`Rename operation complete. ${renamedCount} files renamed, ${skippedCount} files skipped.`);
     } catch (error) {
         logger.error(`Error accessing directory: ${directoryPath}`, handleError(error, args.debug));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export interface CLIArguments {
     path: string;
     debug?: boolean;
+    output: string;
 }


### PR DESCRIPTION
In this PR we have introduced outputing the JSON file from the CLI so that we can utilize this output.json file in our APIs which utilizes these binaries.