### PR TITLE
chore: Release Linux binaries as well.

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,7 +10,8 @@
       {
         "releasedLabels": ["released"],
         "assets": [
-          {"path": "bin/renamer-win.exe", "label": "Renamer Windows x64"}
+          {"path": "bin/renamer-win.exe", "label": "Renamer Windows x64"},
+          {"path": "bin/renamer-linux", "label": "Renamer Linux x64"}
         ]
       }
     ]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf ./lib/ ./dist/",
     "test": "jest",
     "build": "tsc",  
-    "package": "pkg . --targets node18-win-x64 --output ./bin/renamer-win"
+    "package": "pkg . --targets node18-linux-x64,node18-win-x64 --output ./bin/renamer"
   },
   "keywords": [],
   "author": "Deepak Joshi",


### PR DESCRIPTION
In this PR we are releasing the Linux binaries which will be used by our RenamerApp API end point.