### PR TITLE
feat: Introduced naming conventions.

### DIFF
--- a/renamer.ts
+++ b/renamer.ts
@@ -24,6 +24,23 @@ const args: CLIArguments = yargs(hideBin(process.argv))
         type: 'string',
         default: 'renamed.json',
     })
+    .option('namingConvention', {
+        alias: 'nc',
+        describe: 'Choose a naming convention',
+        type: 'string',
+        choices: [
+            'camelCase', 
+            'PascalCase', 
+            'snake_case', 
+            'kebab-case', 
+            'UPPER_SNAKE_CASE', 
+            'Train-Case', 
+            'dot.notation', 
+            'HungarianNotation', 
+            'lisp-case'
+        ],
+        default: 'camelCase',
+    })
     .help()
     .parseSync();
 

--- a/src/__tests__/e2e/renamer.spec.ts
+++ b/src/__tests__/e2e/renamer.spec.ts
@@ -40,4 +40,15 @@ describe('Renamer E2E Tests', () => {
     const files = fs.readdirSync(testDir);
     expect(files).not.toContain('test.md');
   });
+  test('renames files using camelCase naming convention', async () => {
+    const { stdout } = await execa('npx', ['ts-node', 'renamer.ts', '--path', testDir, '--nc', 'camelCase']);
+    expect(stdout).toContain('Starting file renamer...');
+    expect(stdout).toContain('camelCase');
+    expect(stdout).toContain('Rename operation complete');
+    const files = fs.readdirSync(testDir);
+    files.forEach(file => {
+      // Regex for camelCase format file names
+      expect(file).toMatch(/^[a-z][a-zA-Z]*\.[a-z]+$/); 
+    });
+  });
 });

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -3,9 +3,11 @@ import { sanitizeFileName } from "../utils";
 import { extractKeywordsFromMarkdown, extractMarkdownHeadings, extractMarkdownMetadata, extractTopicsFromMarkdown, getPromptForMDContent } from "./utils.markdown";
 import { fileContent, filePath } from "../types/renameFiles";
 import { generateFileName } from "../services/openAI.service";
+import { CLIArguments } from "../types";
+import { basename } from "path";
 
 
-export async function processMarkdownFile(filePath: filePath, content: fileContent): Promise<string | null> {
+export async function processMarkdownFile(filePath: filePath, content: fileContent , args: CLIArguments): Promise<string | null> {
     logger.debug(`Processing markdown file: ${filePath}`);
     const metadata: Record<string, string> | null = extractMarkdownMetadata(content, filePath);
     const headings: string[] = extractMarkdownHeadings(content);
@@ -13,7 +15,8 @@ export async function processMarkdownFile(filePath: filePath, content: fileConte
     const topics: string[] = extractTopicsFromMarkdown(content);
 
     const prompt : string = getPromptForMDContent(metadata, headings, keywords, topics);
-    const suggestedFileName = await generateFileName(prompt);
+    const baseFileName = basename(filePath)
+    const suggestedFileName = await generateFileName(prompt, baseFileName , args );
     if(!suggestedFileName){
         return null;
     }

--- a/src/renameFiles.ts
+++ b/src/renameFiles.ts
@@ -47,7 +47,7 @@ export const renameFilesInDirectory = async (directoryPath: directoryPath, args:
         if (renamedCount > 0) {
             await writeRenamedInfoToFile(renamedInfo, args);
         }
-        logger.info(`Rename operation complete. ${renamedCount} files renamed, ${skippedCount} files skipped.`);
+        logger.info(`Rename operation complete. ${renamedCount} files renamed with the naming convention: "${args.namingConvention}", ${skippedCount} files skipped.`);
     } catch (error) {
         logger.error(`Error accessing directory: ${directoryPath}`, handleError(error, args.debug));
     }

--- a/src/services/openAI.service.ts
+++ b/src/services/openAI.service.ts
@@ -1,23 +1,24 @@
+import { CLIArguments } from "../types";
+import { fileName } from "../types/renameFiles";
 import { cleanFileNameExtension, httpRequest } from "../utils";
 import dotenv from 'dotenv';
 dotenv.config();
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
-
-export const generateFileName = async (content: string): Promise<string> => {
+export const generateFileName = async (content: string, baseFileName:fileName, args: CLIArguments): Promise<string> => {
   try {
     const data = {
       model: 'gpt-4',
       messages: [
         {
-          role: 'system',
-          content: 'You are an AI that generates concise and descriptive file names based on content.'
+            role: 'system',
+            content: `You are an AI tasked with generating concise, descriptive file names based on the provided content. Use the "${args.namingConvention}" naming convention. If the current file name "${baseFileName}" is already appropriate, return it as it is without anything else . Otherwise, suggest a more suitable name that adheres to the convention.`
         },
         {
-          role: 'user',
-          content: `Hi I need a file name for the following content , please provide a concise and descriptive file name that will help me recongnize the content inside the file quickly and easily , it should be short and easy to remember. Content: ${content}`,
+            role: 'user',
+            content: `The current file name is "${baseFileName}". Please evaluate the suitability of this name based on the content provided below. If it's already appropriate then please donot explicitly update that , if it is making sense according to the content provided then we should not suggest a new name and return the current file name only , we should only suggest a new name if the file name is irrelevant to the content present in it. Otherwise, suggest a more suitable name that adheres to the "${args.namingConvention}" convention. Content: ${content}`,
         }
-      ],
+    ],    
       max_tokens: 10,
     };
 

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -3,10 +3,12 @@ import { generateFileName } from "../services/openAI.service";
 import logger from "../../logger";
 import { sanitizeFileName } from "../utils";
 import { fileContent, filePath } from "../types/renameFiles";
+import { CLIArguments } from "../types";
 
-export async function processTextFile(filePath: filePath, content: fileContent): Promise<string | null> {
+export async function processTextFile(filePath: filePath, content: fileContent, args: CLIArguments): Promise<string | null> {
     logger.debug(`Processing text file: ${filePath}`);
-    const suggestedFileName = await generateFileName(content);
+    const baseFileName = basename(filePath)
+    const suggestedFileName = await generateFileName(content , baseFileName , args);
     if (!suggestedFileName) {
         logger.error(`Failed to generate a new file name for ${basename(filePath)}`);
         return null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,4 +2,5 @@ export interface CLIArguments {
     path: string;
     debug?: boolean;
     output: string;
+    namingConvention: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,13 +67,13 @@ async function readFileContent(filePath: filePath): Promise<fileContent | null> 
     }
 }
 
-async function determineNewFileName(filePath: filePath, content: fileContent): Promise<fileName | null> {
+async function determineNewFileName(filePath: filePath, content: fileContent , args: CLIArguments): Promise<fileName | null> {
     const fileExtension = extname(filePath);
 
     if (fileExtension === '.txt') {
-        return await processTextFile(filePath, content);
+        return await processTextFile(filePath, content , args);
     } else if (fileExtension === '.md') {
-        return await processMarkdownFile(filePath, content);
+        return await processMarkdownFile(filePath, content , args);
     } else {
         logger.info(`Skipping unsupported file type: ${basename(filePath)}`);
         return null;
@@ -96,8 +96,12 @@ async function renameFileIfNecessary(filePath: filePath, newFileName: fileName):
     const fileExtension = extname(filePath);
     
     const directoryPath = resolve(filePath, '..');
+
+    const newFileHasExtension = extname(newFileName) === fileExtension;
+
+    const finalFileName = newFileHasExtension ? newFileName : `${newFileName}${fileExtension}`;
     
-    const newFilePath = resolve(directoryPath, `${newFileName}${fileExtension}`);
+    const newFilePath = resolve(directoryPath, finalFileName);
     
     const resolvedFilePath = resolve(filePath);
 
@@ -126,7 +130,7 @@ export async function processFile(filePath: filePath, args: CLIArguments): Promi
         if (!content) return { status: 'skipped', newFilePath: null };
 
         
-        const newFileName = await determineNewFileName(filePath, content);
+        const newFileName = await determineNewFileName(filePath, content , args);
         if (!newFileName) return { status: 'skipped', newFilePath: null };
 
         


### PR DESCRIPTION
In this PR we have Introduced the '--nc' flag to the CLI. It includes providing the type of naming convention we want to follow for the re-named files. 
            'camelCase', 
            'PascalCase', 
            'snake_case', 
            'kebab-case', 
            'UPPER_SNAKE_CASE', 
            'Train-Case', 
            'dot.notation', 
            'HungarianNotation', 
            'lisp-case'
Added test cases arount the change and also updated the LLM prompt.