### PR TITLE
feat: Introduced JavaScript file renaming to the CLI.

### DIFF
--- a/src/__tests__/unit/javaScript.spec.ts
+++ b/src/__tests__/unit/javaScript.spec.ts
@@ -1,4 +1,4 @@
-import { processTypeScriptFile } from '../../code/typeScript/processTypeScriptFile';
+import { processJavaScriptFile } from '../../code/javaScript/processJavaScriptFile';
 import { generateFileName } from '../../services/openAI.service';
 import { CLIArguments } from '../../types';
 import { sanitizeFileName } from '../../utils';
@@ -37,7 +37,7 @@ describe('processTypeScriptFile', () => {
     });
 
     it('should return null for empty file content', async () => {
-        const result = await processTypeScriptFile(mockFilePath, '', mockArgs);
+        const result = await processJavaScriptFile(mockFilePath, '', mockArgs);
 
         expect(result).toBeNull();
         expect(console.warn).toHaveBeenCalledWith(`File ${mockFilePath} is empty, skipping renaming.`);
@@ -55,7 +55,7 @@ describe('processTypeScriptFile', () => {
         (generateFileName as jest.Mock).mockResolvedValue(mockSuggestedFileName);
         (sanitizeFileName as jest.Mock).mockReturnValue(mockSuggestedFileName);
 
-        const result = await processTypeScriptFile(mockFilePath, mockContent, mockArgs);
+        const result = await processJavaScriptFile(mockFilePath, mockContent, mockArgs);
 
         expect(path.basename).toHaveBeenCalledWith(mockFilePath);
         expect(generateFileName).toHaveBeenCalledWith(expect.any(String), 'test.ts', mockArgs);
@@ -67,7 +67,7 @@ describe('processTypeScriptFile', () => {
         const mockError = new Error('Parsing error');
         (generateFileName as jest.Mock).mockRejectedValue(mockError);
 
-        const result = await processTypeScriptFile(mockFilePath, 'some invalid content', mockArgs);
+        const result = await processJavaScriptFile(mockFilePath, 'some invalid content', mockArgs);
 
         expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error processing TypeScript file:'));
         expect(result).toBeNull();

--- a/src/code/javaScript/processJavaScriptFile.ts
+++ b/src/code/javaScript/processJavaScriptFile.ts
@@ -3,8 +3,9 @@ import { CLIArguments } from "../../types";
 import { generateFileName } from '../../services/openAI.service';
 import { basename } from 'path';
 import { sanitizeFileName } from '../../utils';
+import { fileContent, filePath } from '../../types/renameFiles';
 
-export const processTypeScriptFile = async (filePath: string, content: string, args: CLIArguments): Promise<string | null> => {
+export const processJavaScriptFile = async (filePath: filePath, content: fileContent, args: CLIArguments): Promise<string | null> => {
     try {
         if (!content || content.trim().length === 0) {
             console.warn(`File ${filePath} is empty, skipping renaming.`);
@@ -53,7 +54,7 @@ export const processTypeScriptFile = async (filePath: string, content: string, a
         });
 
         const prompt = `
-      The file contains the following TypeScript elements:
+      The file contains the following JavaScript elements:
       - Functions: ${functions.join(", ")}
       - Classes: ${classes.join(", ")}
       - Constants: ${constants.join(", ")}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import { handleError } from "./error/errorHandler";
 import fs, { promises as fsPromises } from 'fs';
 import { processMarkdownFile } from "./markdown";
 import { processTextFile } from "./text";
-import { processTypeScriptFile } from "./code/typeScript/processTypeScriptFile";
+import { processJavaScriptFile } from "./code/javaScript/processJavaScriptFile";
 
 const { access, readFile, rename } = fsPromises;
 
@@ -75,8 +75,8 @@ async function determineNewFileName(filePath: filePath, content: fileContent , a
     } else if (fileExtension === '.md') {
         return await processMarkdownFile(filePath, content , args);
     }
-    if (fileExtension === '.ts') {
-        return await processTypeScriptFile(filePath, content , args);
+    if (fileExtension === '.ts' || fileExtension === '.js') {
+        return await processJavaScriptFile(filePath, content , args);
     } else {
         logger.info(`Skipping unsupported file type: ${basename(filePath)}`);
         return null;

--- a/testData/test.js
+++ b/testData/test.js
@@ -1,0 +1,6 @@
+const sum = (a, b) => {
+    return a + b;
+};
+
+console.log('Hello, world!');
+console.log(sum(1, 2));


### PR DESCRIPTION
In this PR I have merged the `processTypeScriptFile.ts` to include the renaming feature for the `javaScript` file as well. The reason to do this is our convention on renaming files is sort of very similar for typescript and javascript.