### PR TITLE
feat: Introduced jsx renaming to the CLI

### DIFF
--- a/src/__tests__/e2e/renamer.spec.ts
+++ b/src/__tests__/e2e/renamer.spec.ts
@@ -11,6 +11,7 @@ describe('Renamer E2E Tests', () => {
       fs.writeFileSync(path.join(testDir, 'test.txt'), 'Sample content');
       fs.writeFileSync(path.join(testDir, 'test.md'), '---\ntitle: Test Title\nauthor: John Doe\n---\n# Heading 1\n## Heading 2\nThis is a test content about Node.js and Markdown.');
       fs.writeFileSync(path.join(testDir, 'test.ts'), 'export const sum = (a: number, b: number): number => { return a + b; };');
+      fs.writeFileSync(path.join(testDir, 'test.jsx'), 'import React from \'react\';\n\nconst Greeting = () => {\n  const name = "John";\n  const isMorning = true;\n\n  return (\n    <div>\n      <h1>Hello, {name}!</h1>\n      <p>Good {isMorning ? \'morning\' : \'evening\'}!</p>\n      <button onClick={() => alert(\'Welcome to React!\')}>Click Me</button>\n    </div>\n  );\n};\n\nexport default Greeting;');
     }
   });
 
@@ -59,6 +60,15 @@ describe('Renamer E2E Tests', () => {
     expect(stdout).toContain('Renamed test.ts to');
     const files = fs.readdirSync(testDir);
     expect(files).not.toContain('test.ts');
+  });
+  
+  test('renames JSX files as expected', async () => {
+    const jsxFilePath = path.join(testDir, 'test.jsx');
+    const { stdout } = await execa('npx', ['ts-node', 'renamer.ts', '--path', jsxFilePath, '--debug']);
+    expect(stdout).toContain('Starting file renamer...');
+    expect(stdout).toContain('Renamed test.jsx to');
+    const files = fs.readdirSync(testDir);
+    expect(files).not.toContain('test.jsx');
   });
 
 });

--- a/src/code/javaScript/processJavaScriptFile.ts
+++ b/src/code/javaScript/processJavaScriptFile.ts
@@ -11,7 +11,7 @@ export const processJavaScriptFile = async (filePath: filePath, content: fileCon
             console.warn(`File ${filePath} is empty, skipping renaming.`);
             return null;  
         }
-        const parsedAST = parse(content, { loc: true });
+        const parsedAST = parse(content, { loc: true , jsx: true });
 
         const functions: string[] = [];
         const classes: string[] = [];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,7 +75,7 @@ async function determineNewFileName(filePath: filePath, content: fileContent , a
     } else if (fileExtension === '.md') {
         return await processMarkdownFile(filePath, content , args);
     }
-    if (fileExtension === '.ts' || fileExtension === '.js') {
+    if (fileExtension === '.ts' || fileExtension === '.js' || fileExtension === '.jsx') {
         return await processJavaScriptFile(filePath, content , args);
     } else {
         logger.info(`Skipping unsupported file type: ${basename(filePath)}`);

--- a/testData/test.jsx
+++ b/testData/test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const Greeting = () => {
+  const name = "John";
+  const isMorning = true;
+
+  return (
+    <div>
+      <h1>Hello, {name}!</h1>
+      <p>Good {isMorning ? 'morning' : 'evening'}!</p>
+      <button onClick={() => alert('Welcome to React!')}>Click Me</button>
+    </div>
+  );
+};
+
+export default Greeting;


### PR DESCRIPTION
In this PR we are introducing JSX renaming. It is also done usnig `typescript-estree` just with `jsx=true` flag.