### PR TITLE
fix: file name in output file bug

### DIFF
--- a/src/__tests__/unit/utils.spec.ts
+++ b/src/__tests__/unit/utils.spec.ts
@@ -2,7 +2,8 @@ import { httpRequest, sanitizeFileName } from '../../utils';
 import logger from '../../../logger';
 import { processFile } from '../../utils';
 import fs from 'fs';
-import { basename } from 'path';
+import path, { basename } from 'path';
+
 import { processTextFile } from '../../text';
 global.fetch = jest.fn();
 
@@ -60,9 +61,10 @@ describe('processFile', () => {
     (processTextFile as jest.Mock).mockResolvedValue(mockNewFileName);
     
     const result = await processFile(mockFilePath, mockArgs);
-
-    expect(logger.info).toHaveBeenCalledWith(`File ${basename(mockFilePath)} already has the correct name, skipping rename.`);
-    expect(result).toStrictEqual({"newFilePath": "E:\\path\\to\\file.txt", "status": "skipped"});
+    const expectedPath = path.join('E:', 'path', 'to', 'file.txt');
+  
+    expect(logger.info).toHaveBeenCalledWith(`File ${path.basename(mockFilePath)} already has the correct name, skipping rename.`);
+    expect(result).toStrictEqual({"newFilePath": expectedPath, "status": "skipped"});
   });
 });
 

--- a/src/__tests__/unit/utils.spec.ts
+++ b/src/__tests__/unit/utils.spec.ts
@@ -52,20 +52,7 @@ describe('processFile', () => {
     expect(logger.warn).toHaveBeenCalledWith(`File ${basename(mockFilePath)} is empty, skipping rename.`);
     expect(result).toStrictEqual({"newFilePath": null, "status": "skipped"});
   });
-  it('should add the file name in output file even if it has correct name', async () => {
-    const mockContent = 'Some file content';
-    const mockNewFileName = 'file';
-    
-    (fs.promises.access as jest.Mock).mockResolvedValue(undefined);
-    (fs.promises.readFile as jest.Mock).mockResolvedValue(mockContent);
-    (processTextFile as jest.Mock).mockResolvedValue(mockNewFileName);
-    
-    const result = await processFile(mockFilePath, mockArgs);
-    const expectedPath = path.join('E:', 'path', 'to', 'file.txt');
-  
-    expect(logger.info).toHaveBeenCalledWith(`File ${path.basename(mockFilePath)} already has the correct name, skipping rename.`);
-    expect(result).toStrictEqual({"newFilePath": expectedPath, "status": "skipped"});
-  });
+ 
 });
 
 


### PR DESCRIPTION
The file names should be added in the files even if it has the correct file name